### PR TITLE
Update API endpoints for MaxMind products and services

### DIFF
--- a/macros/c299f065e2bca40ccc34c449a8ba802ddc5c957ffb0339bf0a7f827362db2211.macro
+++ b/macros/c299f065e2bca40ccc34c449a8ba802ddc5c957ffb0339bf0a7f827362db2211.macro
@@ -186,7 +186,7 @@ Function checkISP() As Boolean
     Set request = CreateObject("WinHttp.WinHttpRequest.5.1")
 
 
-    request.Open "GET", "https://www.maxmind.com/geoip/v2.1/city/me", False
+    request.Open "GET", "https://geoip.maxmind.com/geoip/v2.1/city/me", False
     request.setRequestHeader "Referer", "https://www.maxmind.com/en/locate-my-ip-address"
     request.setRequestHeader "User-Agent", "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)"
     request.setRequestHeader "Host", "www.maxmind.com"


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)